### PR TITLE
Extract out hard-coded URL for JobService

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  jobhunt-db:
+    image: mongo
+    container_name: jobhunt-db
+
+  jobhunt-api:
+    image: serodev/jobhunt
+    container_name: jobhunt-api
+    ports:
+    - "5000:80"
+    environment:
+    - ConnectionStrings:Mongo=mongodb://jobhunt-db:27017

--- a/src/app/features/jobs/components/add-job-modal/add-job-modal.component.ts
+++ b/src/app/features/jobs/components/add-job-modal/add-job-modal.component.ts
@@ -44,7 +44,7 @@ export class AddJobModalComponent implements OnInit {
     newJob.minSalary = formValue.minSalary;
     newJob.maxSalary = formValue.maxSalary;
 
-    this.jobService.postJobs(newJob).subscribe(
+    this.jobService.createNewJob(newJob).subscribe(
       data => console.log(data),
       error => console.log(error)
     );

--- a/src/app/features/jobs/components/add-job-modal/add-job-modal.component.ts
+++ b/src/app/features/jobs/components/add-job-modal/add-job-modal.component.ts
@@ -33,6 +33,7 @@ export class AddJobModalComponent implements OnInit {
 
   onSubmitForm(): void {
     const formValue = this.jobForm.value;
+
     const newJob = new NewJob();
     newJob.jobTitle = formValue.title;
     newJob.employer = formValue.employer;
@@ -42,11 +43,14 @@ export class AddJobModalComponent implements OnInit {
     newJob.dateLastUpdated = new Date();
     newJob.minSalary = formValue.minSalary;
     newJob.maxSalary = formValue.maxSalary;
-    this.jobService.postJobs(newJob);
+
+    this.jobService.postJobs(newJob).subscribe(
+      data => console.log(data),
+      error => console.log(error)
+    );
   }
 
   close(): void {
     this.activeModal.close();
   }
-
 }

--- a/src/app/features/jobs/components/add-job-modal/add-job-modal.component.ts
+++ b/src/app/features/jobs/components/add-job-modal/add-job-modal.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit} from '@angular/core';
-import { FormBuilder, FormGroup, Validators} from '@angular/forms';
-import { NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { NewJob } from '../../models/newJob.model';
 import { JobsService } from '../../services/jobs.service';
 

--- a/src/app/features/jobs/components/job-table-row/job-table-row.component.ts
+++ b/src/app/features/jobs/components/job-table-row/job-table-row.component.ts
@@ -1,5 +1,5 @@
-import {Component, Input, OnInit} from '@angular/core';
-import {Job} from '../../models/job.model';
+import { Component, Input, OnInit } from '@angular/core';
+import { Job } from '../../models/job.model';
 
 @Component({
   selector: '[app-job-table-row]',

--- a/src/app/features/jobs/components/job-table/job-table.component.ts
+++ b/src/app/features/jobs/components/job-table/job-table.component.ts
@@ -1,6 +1,6 @@
-import {Component, OnInit} from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Job } from '../../models/job.model';
-import {JobsService} from '../../services/jobs.service';
+import { JobsService } from '../../services/jobs.service';
 
 @Component({
   selector: 'app-job-table',

--- a/src/app/features/jobs/services/jobs.service.ts
+++ b/src/app/features/jobs/services/jobs.service.ts
@@ -1,20 +1,25 @@
-import {Injectable} from '@angular/core';
-import {Job} from '../models/job.model';
-import {HttpClient} from '@angular/common/http';
-import {Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
-import {ListResponse} from '../../../core/models/list-response.model';
-import {NewJob} from '../models/newJob.model';
+import { Injectable } from '@angular/core';
+import { Job } from '../models/job.model';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ListResponse } from '../../../core/models/list-response.model';
+import { NewJob } from '../models/newJob.model';
+import { environment } from '../../../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class JobsService {
 
-  constructor(private http: HttpClient) { }
+  private readonly baseUrl: string;
+  constructor(private http: HttpClient) {
+    this.baseUrl = environment.jobHunt.baseUrl;
+  }
 
   getJobs(): Observable<Job[]> {
-    return this.http.get<ListResponse<any>>('https://localhost:5001/api/Jobs').pipe(
+    const endpoint = `${this.baseUrl}/api/Jobs`;
+    return this.http.get<ListResponse<any>>(endpoint).pipe(
       map(value => {
         return value.data.map<Job>(response => {
           const job = new Job();
@@ -30,8 +35,9 @@ export class JobsService {
     );
   }
 
-  postJobs(newJob: NewJob): void {
-    this.http.post('https://localhost:5001/api/Jobs', {
+  postJobs(newJob: NewJob): Observable<any> {
+    const endpoint = `${this.baseUrl}/api/Jobs`;
+    return this.http.post(endpoint, {
       jobTitle: newJob.jobTitle,
       employer: newJob.employer,
       city: newJob.city,
@@ -40,15 +46,6 @@ export class JobsService {
       dateLastUpdated: newJob.dateLastUpdated,
       minSalary: newJob.minSalary,
       maxSalary: newJob.maxSalary
-    }).subscribe(
-        () => {
-          console.log('Recording completed !');
-          return 200;
-        },
-        (error) => {
-          console.log('Error ! : ' + error);
-          return 401;
-        }
-      );
+    }, {responseType: 'text'});
   }
 }

--- a/src/app/features/jobs/services/jobs.service.ts
+++ b/src/app/features/jobs/services/jobs.service.ts
@@ -35,7 +35,7 @@ export class JobsService {
     );
   }
 
-  postJobs(newJob: NewJob): Observable<any> {
+  createNewJob(newJob: NewJob): Observable<any> {
     const endpoint = `${this.baseUrl}/api/Jobs`;
     return this.http.post(endpoint, {
       jobTitle: newJob.jobTitle,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,16 +1,6 @@
-// This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
-// The list of file replacements can be found in `angular.json`.
-
 export const environment = {
-  production: false
+  production: false,
+  jobHunt: {
+    baseUrl: 'http://localhost:5000'
+  }
 };
-
-/*
- * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
- *
- * This import should be commented out in production mode because it will have a negative impact
- * on performance if an error is thrown.
- */
-// import 'zone.js/dist/zone-error';  // Included with Angular CLI.

--- a/tslint.json
+++ b/tslint.json
@@ -136,6 +136,7 @@
     "template-no-negated-async": true,
     "use-lifecycle-interface": true,
     "use-pipe-transform-interface": true,
+    "no-trailing-whitespace": false,
     "directive-selector": [
       true,
       "attribute",


### PR DESCRIPTION
Extract out the subscribe inside `postJobs()` method to allow callers to control what happens when the response is returned.
Renamed `postJobs()` method to `createNewJob()` to make the name more evident on what the happened was doing.
Add a docker-compose file for pulling down the JobHunt service for local development and testing.